### PR TITLE
Fix/back button color

### DIFF
--- a/CartWise.xcodeproj/project.pbxproj
+++ b/CartWise.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7F4FACBD2E25B4E300633226 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 6086E4E42E22E7B500E6A19C /* FirebaseAuth */; };
+		7F4FACBE2E25B4E300633226 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 6086E4E62E22E7B500E6A19C /* FirebaseFirestore */; };
+		7F4FAD142E25B53200633226 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4FAD132E25B53200633226 /* APIService.swift */; };
 		D572E21B2E199B420061F187 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D572E2162E199B420061F187 /* Assets.xcassets */; };
 		D572E21C2E199B420061F187 /* CartWiseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D572E2172E199B420061F187 /* CartWiseApp.swift */; };
 		D572E2212E199B460061F187 /* CartWiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D572E21F2E199B460061F187 /* CartWiseTests.swift */; };
@@ -34,6 +37,7 @@
 
 /* Begin PBXFileReference section */
 		57E0A8172E1F214300A52D48 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		7F4FAD132E25B53200633226 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		D572E1EA2E199B370061F187 /* CartWise.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CartWise.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D572E1F92E199B380061F187 /* CartWiseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CartWiseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D572E2032E199B380061F187 /* CartWiseUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CartWiseUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,8 +87,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6086E4E52E22E7B500E6A19C /* FirebaseAuth in Frameworks */,
-				6086E4E72E22E7B500E6A19C /* FirebaseFirestore in Frameworks */,
+				7F4FACBE2E25B4E300633226 /* FirebaseFirestore in Frameworks */,
+				7F4FACBD2E25B4E300633226 /* FirebaseAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,7 +132,6 @@
 		D572E21A2E199B420061F187 /* CartWise */ = {
 			isa = PBXGroup;
 			children = (
-				6086E4E12E22E61300E6A19C /* GoogleService-Info.plist */,
 				6086E4DD2E22D8F900E6A19C /* Utilities */,
 				57E0A8172E1F214300A52D48 /* Info.plist */,
 				57E0A7EB2E1F1BA300A52D48 /* Resources */,
@@ -163,7 +166,7 @@
 		D572E25D2E1C53AC0061F187 /* Repository */ = {
 			isa = PBXGroup;
 			children = (
-				57E0AAED2E21DFB200A52D48 /* APIService.swift */,
+				7F4FAD132E25B53200633226 /* APIService.swift */,
 				D572E25E2E1C53B60061F187 /* Repository.swift */,
 			);
 			path = Repository;
@@ -294,7 +297,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D572E21B2E199B420061F187 /* Assets.xcassets in Resources */,
-				6086E4E22E22E61300E6A19C /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -319,7 +321,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				57E0AAEE2E21DFB200A52D48 /* APIService.swift in Sources */,
+				7F4FAD142E25B53200633226 /* APIService.swift in Sources */,
 				D572E21C2E199B420061F187 /* CartWiseApp.swift in Sources */,
 				D572E25F2E1C53BA0061F187 /* Repository.swift in Sources */,
 			);

--- a/CartWise.xcodeproj/project.pbxproj
+++ b/CartWise.xcodeproj/project.pbxproj
@@ -7,9 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7F4FACBD2E25B4E300633226 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 6086E4E42E22E7B500E6A19C /* FirebaseAuth */; };
-		7F4FACBE2E25B4E300633226 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 6086E4E62E22E7B500E6A19C /* FirebaseFirestore */; };
-		7F4FAD142E25B53200633226 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4FAD132E25B53200633226 /* APIService.swift */; };
 		D572E21B2E199B420061F187 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D572E2162E199B420061F187 /* Assets.xcassets */; };
 		D572E21C2E199B420061F187 /* CartWiseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D572E2172E199B420061F187 /* CartWiseApp.swift */; };
 		D572E2212E199B460061F187 /* CartWiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D572E21F2E199B460061F187 /* CartWiseTests.swift */; };
@@ -37,7 +34,6 @@
 
 /* Begin PBXFileReference section */
 		57E0A8172E1F214300A52D48 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		7F4FAD132E25B53200633226 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		D572E1EA2E199B370061F187 /* CartWise.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CartWise.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D572E1F92E199B380061F187 /* CartWiseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CartWiseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D572E2032E199B380061F187 /* CartWiseUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CartWiseUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -87,8 +83,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7F4FACBE2E25B4E300633226 /* FirebaseFirestore in Frameworks */,
-				7F4FACBD2E25B4E300633226 /* FirebaseAuth in Frameworks */,
+				6086E4E52E22E7B500E6A19C /* FirebaseAuth in Frameworks */,
+				6086E4E72E22E7B500E6A19C /* FirebaseFirestore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -132,6 +128,7 @@
 		D572E21A2E199B420061F187 /* CartWise */ = {
 			isa = PBXGroup;
 			children = (
+				6086E4E12E22E61300E6A19C /* GoogleService-Info.plist */,
 				6086E4DD2E22D8F900E6A19C /* Utilities */,
 				57E0A8172E1F214300A52D48 /* Info.plist */,
 				57E0A7EB2E1F1BA300A52D48 /* Resources */,
@@ -166,7 +163,7 @@
 		D572E25D2E1C53AC0061F187 /* Repository */ = {
 			isa = PBXGroup;
 			children = (
-				7F4FAD132E25B53200633226 /* APIService.swift */,
+				57E0AAED2E21DFB200A52D48 /* APIService.swift */,
 				D572E25E2E1C53B60061F187 /* Repository.swift */,
 			);
 			path = Repository;
@@ -297,6 +294,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D572E21B2E199B420061F187 /* Assets.xcassets in Resources */,
+				6086E4E22E22E61300E6A19C /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -321,7 +319,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7F4FAD142E25B53200633226 /* APIService.swift in Sources */,
+				57E0AAEE2E21DFB200A52D48 /* APIService.swift in Sources */,
 				D572E21C2E199B420061F187 /* CartWiseApp.swift in Sources */,
 				D572E25F2E1C53BA0061F187 /* Repository.swift in Sources */,
 			);

--- a/CartWise.xcodeproj/project.pbxproj
+++ b/CartWise.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		D572E2252E199B490061F187 /* CartWiseUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D572E2222E199B490061F187 /* CartWiseUITests.swift */; };
 		D572E2262E199B490061F187 /* CartWiseUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D572E2232E199B490061F187 /* CartWiseUITestsLaunchTests.swift */; };
 		D572E25F2E1C53BA0061F187 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D572E25E2E1C53B60061F187 /* Repository.swift */; };
+		57E0AAEE2E21DFB200A52D48 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E0AAED2E21DFB200A52D48 /* APIService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,6 +44,7 @@
 		D572E2222E199B490061F187 /* CartWiseUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartWiseUITests.swift; sourceTree = "<group>"; };
 		D572E2232E199B490061F187 /* CartWiseUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartWiseUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		D572E25E2E1C53B60061F187 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
+		57E0AAED2E21DFB200A52D48 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */

--- a/CartWise/Assets.xcassets/AccentColorBlue.colorset/Contents.json
+++ b/CartWise/Assets.xcassets/AccentColorBlue.colorset/Contents.json
@@ -1,0 +1,41 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.645",
+          "green" : "0.465",
+          "red" : "0.317"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.908",
+          "green" : "0.683",
+          "red" : "0.495"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/CartWise/Navigation/AppCoordinator.swift
+++ b/CartWise/Navigation/AppCoordinator.swift
@@ -68,6 +68,7 @@ struct AppCoordinatorView: View {
                             Text(TabItem.searchItems.rawValue)
                         }
                         .tag(TabItem.searchItems)
+                        .tint(Color.accentColorBlue)
                     
                     AddItemsView()
                         .tabItem {
@@ -84,7 +85,7 @@ struct AppCoordinatorView: View {
                             Text(TabItem.myProfile.rawValue)
                         }
                         .tag(TabItem.myProfile)
-                }
+                }.tint(Color.accentColorBlue)
             } else {
                 LoginView()
             }


### PR DESCRIPTION
## Description
* Fixed visibility issues with back button text color in CategoryItemsView and bottom menu tab navigation. The back button text was appearing white, making it difficult to see against light backgrounds.
Problem
* Back button text ("< Categories") was white and not visible

## Solution
* Added custom accentColorBlue color
* Applied .tint(Color.accentColorBlue) modifiers in AppCoordinatorView

## Changes Made
* CategoryItemsView.swift: Added custom color styling for back button
* Bottom Menu Tab: Applied consistent color scheme across navigation

## Testing
* Verified back button is now visible with proper contrast
* Tested navigation flow from SearchItemsView → CategoryItemsView

## Screenshots
### Before
* Selected tab icon/front missing:
<img width="380" height="827" alt="Selected tab icon/front missing" src="https://github.com/user-attachments/assets/09cc2bb5-7a2c-4289-b1fa-24ebb69cce32" />
<p align="center">
  <img width="380" height="827" alt="Selected tab icon/front missing" src="https://github.com/user-attachments/assets/09cc2bb5-7a2c-4289-b1fa-24ebb69cce32" />
</p>

* Back button missing: 
<img width="378" height="828" alt="Back button missing" src="https://github.com/user-attachments/assets/53fe17f3-4c2a-4f42-ab8c-f5e4141502b1" />

### After
* Selected tab is visible and in different color:
<img width="379" height="832" alt="Selected tab is visible and in different color" src="https://github.com/user-attachments/assets/fb629539-dc28-44ab-a7f6-560cd660b345" />

* Back button visible:
<img width="382" height="827" alt="Back button visible" src="https://github.com/user-attachments/assets/830c8eca-21c0-4a77-b9f3-72f995686af9" />

## Related Issues
* Fixes #11  Back button visibility issue