### PR TITLE
Fixes #65

### DIFF
--- a/CartWise/Views/EditLocationView.swift
+++ b/CartWise/Views/EditLocationView.swift
@@ -309,13 +309,13 @@ struct EditLocationView: View {
                 // Check for duplicate address (excluding current location)
                 let locationFetchRequest: NSFetchRequest<Location> = Location.fetchRequest()
                 locationFetchRequest.predicate = NSPredicate(
-                    format: "user == %@ AND address == %@ AND city == %@ AND state == %@ AND zipCode == %@ AND objectID != %@",
+                    format: "user == %@ AND address == %@ AND city == %@ AND state == %@ AND zipCode == %@ AND SELF != %@",
                     currentUser,
                     address.trimmingCharacters(in: .whitespacesAndNewlines),
                     city.trimmingCharacters(in: .whitespacesAndNewlines),
                     state.trimmingCharacters(in: .whitespacesAndNewlines),
                     zipCode.trimmingCharacters(in: .whitespacesAndNewlines),
-                    location.objectID
+                    location
                 )
                 
                 let existingLocations = try viewContext.fetch(locationFetchRequest)
@@ -362,13 +362,13 @@ struct EditLocationView: View {
                     // Check for duplicate address (excluding current location)
                     let locationFetchRequest: NSFetchRequest<Location> = Location.fetchRequest()
                     locationFetchRequest.predicate = NSPredicate(
-                        format: "user == %@ AND address == %@ AND city == %@ AND state == %@ AND zipCode == %@ AND objectID != %@",
+                        format: "user == %@ AND address == %@ AND city == %@ AND state == %@ AND zipCode == %@ AND SELF != %@",
                         currentUser,
                         address.trimmingCharacters(in: .whitespacesAndNewlines),
                         city.trimmingCharacters(in: .whitespacesAndNewlines),
                         state.trimmingCharacters(in: .whitespacesAndNewlines),
                         zipCode.trimmingCharacters(in: .whitespacesAndNewlines),
-                        location.objectID
+                        location
                     )
                     
                     let existingLocations = try viewContext.fetch(locationFetchRequest)

--- a/CartWise/Views/EditLocationView.swift
+++ b/CartWise/Views/EditLocationView.swift
@@ -1,0 +1,447 @@
+//
+//  EditLocationView.swift
+//  CartWise
+//
+//  Created by AI Assistant on 12/19/24.
+//
+
+import SwiftUI
+import CoreData
+
+struct EditLocationView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.managedObjectContext) private var viewContext
+    @EnvironmentObject var productViewModel: ProductViewModel
+    
+    let location: Location
+    
+    @State private var name: String = ""
+    @State private var address: String = ""
+    @State private var city: String = ""
+    @State private var state: String = ""
+    @State private var zipCode: String = ""
+    @State private var favorited: Bool = false
+    @State private var isDefault: Bool = false
+    @State private var isLoading: Bool = false
+    @State private var showError: Bool = false
+    @State private var errorMessage: String = ""
+    @State private var isCheckingAddress: Bool = false
+    @State private var isAddressDuplicate: Bool = false
+    @State private var showDeleteAlert: Bool = false
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                // Background
+                AppColors.backgroundSecondary
+                    .ignoresSafeArea()
+                
+                ScrollView {
+                    VStack(spacing: 24) {
+                        // Header
+                        VStack(spacing: 8) {
+                            Image(systemName: "location.circle.fill")
+                                .font(.system(size: 48))
+                                .foregroundColor(AppColors.accentGreen)
+                            
+                            Text("Edit Location")
+                                .font(.poppins(size: 24, weight: .bold))
+                                .foregroundColor(AppColors.textPrimary)
+                            
+                            Text("Update your location information")
+                                .font(.poppins(size: 16, weight: .regular))
+                                .foregroundColor(.gray)
+                                .multilineTextAlignment(.center)
+                        }
+                        .padding(.top, 20)
+                        
+                        // Form
+                        VStack(spacing: 20) {
+                            // Location Name
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Location Name")
+                                    .font(.poppins(size: 16, weight: .semibold))
+                                    .foregroundColor(AppColors.textPrimary)
+                                
+                                TextField("e.g., Home, Work, Mom's House", text: $name)
+                                    .textFieldStyle(CustomTextFieldStyle())
+                            }
+                            
+                            // Address
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Street Address")
+                                    .font(.poppins(size: 16, weight: .semibold))
+                                    .foregroundColor(AppColors.textPrimary)
+                                
+                                HStack {
+                                    TextField("123 Main Street", text: $address)
+                                        .textFieldStyle(CustomTextFieldStyle())
+                                        .onChange(of: address) { _ in
+                                            checkAddressAvailability()
+                                        }
+                                    
+                                    if isCheckingAddress {
+                                        ProgressView()
+                                            .scaleEffect(0.8)
+                                            .frame(width: 20, height: 20)
+                                    }
+                                }
+                            }
+                            
+                            // City, State, Zip Row
+                            HStack(spacing: 12) {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text("City")
+                                        .font(.poppins(size: 16, weight: .semibold))
+                                        .foregroundColor(AppColors.textPrimary)
+                                    
+                                    TextField("City", text: $city)
+                                        .textFieldStyle(CustomTextFieldStyle())
+                                        .onChange(of: city) { _ in
+                                            checkAddressAvailability()
+                                        }
+                                }
+                                
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text("State")
+                                        .font(.poppins(size: 16, weight: .semibold))
+                                        .foregroundColor(AppColors.textPrimary)
+                                    
+                                    TextField("State", text: $state)
+                                        .textFieldStyle(CustomTextFieldStyle())
+                                        .onChange(of: state) { _ in
+                                            checkAddressAvailability()
+                                        }
+                                }
+                            }
+                            
+                            // Zip Code
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Zip Code")
+                                    .font(.poppins(size: 16, weight: .semibold))
+                                    .foregroundColor(AppColors.textPrimary)
+                                
+                                TextField("12345", text: $zipCode)
+                                    .textFieldStyle(CustomTextFieldStyle())
+                                    .keyboardType(.numberPad)
+                                    .onChange(of: zipCode) { _ in
+                                        checkAddressAvailability()
+                                    }
+                            }
+                            
+                            // Toggle Options
+                            VStack(spacing: 16) {
+                                Toggle(isOn: $favorited) {
+                                    HStack {
+                                        Image(systemName: "heart.fill")
+                                            .foregroundColor(.red)
+                                        Text("Mark as Favorite")
+                                            .font(.poppins(size: 16, weight: .medium))
+                                            .foregroundColor(AppColors.textPrimary)
+                                    }
+                                }
+                                .toggleStyle(CustomToggleStyle())
+                                
+                                Toggle(isOn: $isDefault) {
+                                    HStack {
+                                        Image(systemName: "star.fill")
+                                            .foregroundColor(.yellow)
+                                        Text("Set as Default Location")
+                                            .font(.poppins(size: 16, weight: .medium))
+                                            .foregroundColor(AppColors.textPrimary)
+                                    }
+                                }
+                                .toggleStyle(CustomToggleStyle())
+                            }
+                        }
+                        .padding(.horizontal, 20)
+                        
+                        // Action Buttons
+                        VStack(spacing: 16) {
+                            // Save Button
+                            Button(action: saveLocation) {
+                                HStack(spacing: 12) {
+                                    if isLoading {
+                                        ProgressView()
+                                            .scaleEffect(0.8)
+                                            .foregroundColor(.white)
+                                    } else {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .font(.system(size: 18, weight: .medium))
+                                    }
+                                    
+                                    Text(isLoading ? "Saving..." : "Save Changes")
+                                        .font(.poppins(size: 18, weight: .semibold))
+                                }
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 56)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 18)
+                                        .fill(
+                                            LinearGradient(
+                                                gradient: Gradient(colors: [
+                                                    AppColors.accentGreen,
+                                                    AppColors.accentGreen.opacity(0.8)
+                                                ]),
+                                                startPoint: .leading,
+                                                endPoint: .trailing
+                                            )
+                                        )
+                                        .shadow(color: AppColors.accentGreen.opacity(0.3), radius: 12, x: 0, y: 6)
+                                )
+                            }
+                            .disabled(isLoading || !isFormValid || isAddressDuplicate)
+                            .opacity((isFormValid && !isAddressDuplicate) ? 1.0 : 0.6)
+                            
+                            // Delete Button
+                            Button(action: {
+                                showDeleteAlert = true
+                            }) {
+                                HStack(spacing: 12) {
+                                    Image(systemName: "trash.circle.fill")
+                                        .font(.system(size: 18, weight: .medium))
+                                    
+                                    Text("Delete Location")
+                                        .font(.poppins(size: 18, weight: .semibold))
+                                }
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 56)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 18)
+                                        .fill(
+                                            LinearGradient(
+                                                gradient: Gradient(colors: [
+                                                    Color.red,
+                                                    Color.red.opacity(0.8)
+                                                ]),
+                                                startPoint: .leading,
+                                                endPoint: .trailing
+                                            )
+                                        )
+                                        .shadow(color: Color.red.opacity(0.3), radius: 12, x: 0, y: 6)
+                                )
+                            }
+                            .disabled(isLoading)
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 32)
+                    }
+                }
+            }
+            .navigationTitle("Edit Location")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .foregroundColor(AppColors.accentGreen)
+                }
+            }
+        }
+        .alert("Error", isPresented: $showError) {
+            Button("OK") { }
+        } message: {
+            Text(errorMessage)
+        }
+        .alert("Delete Location", isPresented: $showDeleteAlert) {
+            Button("Cancel", role: .cancel) { }
+            Button("Delete", role: .destructive) {
+                deleteLocation()
+            }
+        } message: {
+            Text("Are you sure you want to delete this location? This action cannot be undone.")
+        }
+        .onAppear {
+            loadLocationData()
+        }
+    }
+    
+    private var isFormValid: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !city.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !state.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !zipCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    
+    private func loadLocationData() {
+        name = location.name ?? ""
+        address = location.address ?? ""
+        city = location.city ?? ""
+        state = location.state ?? ""
+        zipCode = location.zipCode ?? ""
+        favorited = location.favorited
+        isDefault = location.isDefault
+    }
+    
+    private func checkAddressAvailability() {
+        guard !address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+              !city.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+              !state.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+              !zipCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+        
+        // Don't check if the address hasn't changed
+        let currentAddress = "\(address.trimmingCharacters(in: .whitespacesAndNewlines)), \(city.trimmingCharacters(in: .whitespacesAndNewlines)), \(state.trimmingCharacters(in: .whitespacesAndNewlines)) \(zipCode.trimmingCharacters(in: .whitespacesAndNewlines))"
+        let originalAddress = "\(location.address ?? ""), \(location.city ?? ""), \(location.state ?? "") \(location.zipCode ?? "")"
+        
+        if currentAddress == originalAddress {
+            isAddressDuplicate = false
+            return
+        }
+        
+        isCheckingAddress = true
+        
+        Task {
+            do {
+                // Get current user
+                let fetchRequest: NSFetchRequest<UserEntity> = UserEntity.fetchRequest()
+                fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \UserEntity.createdAt, ascending: false)]
+                fetchRequest.fetchLimit = 1
+                
+                let users = try viewContext.fetch(fetchRequest)
+                guard let currentUser = users.first else { return }
+                
+                // Check for duplicate address (excluding current location)
+                let locationFetchRequest: NSFetchRequest<Location> = Location.fetchRequest()
+                locationFetchRequest.predicate = NSPredicate(
+                    format: "user == %@ AND address == %@ AND city == %@ AND state == %@ AND zipCode == %@ AND objectID != %@",
+                    currentUser,
+                    address.trimmingCharacters(in: .whitespacesAndNewlines),
+                    city.trimmingCharacters(in: .whitespacesAndNewlines),
+                    state.trimmingCharacters(in: .whitespacesAndNewlines),
+                    zipCode.trimmingCharacters(in: .whitespacesAndNewlines),
+                    location.objectID
+                )
+                
+                let existingLocations = try viewContext.fetch(locationFetchRequest)
+                
+                await MainActor.run {
+                    isCheckingAddress = false
+                    isAddressDuplicate = !existingLocations.isEmpty
+                    if isAddressDuplicate {
+                        errorMessage = "This address has already been added to your locations."
+                        showError = true
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    isCheckingAddress = false
+                    isAddressDuplicate = false
+                }
+            }
+        }
+    }
+    
+    private func saveLocation() {
+        guard isFormValid else { return }
+        
+        isLoading = true
+        
+        Task {
+            do {
+                // Final check for duplicate address
+                let currentAddress = "\(address.trimmingCharacters(in: .whitespacesAndNewlines)), \(city.trimmingCharacters(in: .whitespacesAndNewlines)), \(state.trimmingCharacters(in: .whitespacesAndNewlines)) \(zipCode.trimmingCharacters(in: .whitespacesAndNewlines))"
+                let originalAddress = "\(location.address ?? ""), \(location.city ?? ""), \(location.state ?? "") \(location.zipCode ?? "")"
+                
+                if currentAddress != originalAddress {
+                    // Get current user
+                    let fetchRequest: NSFetchRequest<UserEntity> = UserEntity.fetchRequest()
+                    fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \UserEntity.createdAt, ascending: false)]
+                    fetchRequest.fetchLimit = 1
+                    
+                    let users = try viewContext.fetch(fetchRequest)
+                    guard let currentUser = users.first else {
+                        throw LocationError.noUserFound
+                    }
+                    
+                    // Check for duplicate address (excluding current location)
+                    let locationFetchRequest: NSFetchRequest<Location> = Location.fetchRequest()
+                    locationFetchRequest.predicate = NSPredicate(
+                        format: "user == %@ AND address == %@ AND city == %@ AND state == %@ AND zipCode == %@ AND objectID != %@",
+                        currentUser,
+                        address.trimmingCharacters(in: .whitespacesAndNewlines),
+                        city.trimmingCharacters(in: .whitespacesAndNewlines),
+                        state.trimmingCharacters(in: .whitespacesAndNewlines),
+                        zipCode.trimmingCharacters(in: .whitespacesAndNewlines),
+                        location.objectID
+                    )
+                    
+                    let existingLocations = try viewContext.fetch(locationFetchRequest)
+                    
+                    if !existingLocations.isEmpty {
+                        await MainActor.run {
+                            isLoading = false
+                            errorMessage = "This address has already been added to your locations."
+                            showError = true
+                        }
+                        return
+                    }
+                }
+                
+                // If setting as default, unset other defaults
+                if isDefault && !location.isDefault {
+                    let defaultLocationFetchRequest: NSFetchRequest<Location> = Location.fetchRequest()
+                    defaultLocationFetchRequest.predicate = NSPredicate(format: "user == %@ AND isDefault == YES", location.user!)
+                    
+                    let existingDefaults = try viewContext.fetch(defaultLocationFetchRequest)
+                    for existingDefault in existingDefaults {
+                        existingDefault.isDefault = false
+                    }
+                }
+                
+                // Update location
+                location.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+                location.address = address.trimmingCharacters(in: .whitespacesAndNewlines)
+                location.city = city.trimmingCharacters(in: .whitespacesAndNewlines)
+                location.state = state.trimmingCharacters(in: .whitespacesAndNewlines)
+                location.zipCode = zipCode.trimmingCharacters(in: .whitespacesAndNewlines)
+                location.favorited = favorited
+                location.isDefault = isDefault
+                location.updatedAt = Date()
+                
+                try viewContext.save()
+                
+                await MainActor.run {
+                    isLoading = false
+                    dismiss()
+                }
+                
+            } catch {
+                await MainActor.run {
+                    isLoading = false
+                    errorMessage = error.localizedDescription
+                    showError = true
+                }
+            }
+        }
+    }
+    
+    private func deleteLocation() {
+        isLoading = true
+        
+        Task {
+            do {
+                viewContext.delete(location)
+                try viewContext.save()
+                
+                await MainActor.run {
+                    isLoading = false
+                    dismiss()
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading = false
+                    errorMessage = "Failed to delete location: \(error.localizedDescription)"
+                    showError = true
+                }
+            }
+        }
+    }
+}
+
+ 

--- a/CartWise/Views/LocationsSectionView.swift
+++ b/CartWise/Views/LocationsSectionView.swift
@@ -155,7 +155,7 @@ struct LocationsSectionView: View {
                 ScrollView {
                     LazyVStack(spacing: 16) {
                         ForEach(locations) { location in
-                            LocationRowView(location: location)
+                            LocationRowView(location: location, productViewModel: productViewModel)
                         }
                     }
                     .padding(.horizontal, 20)
@@ -220,9 +220,14 @@ struct LocationsSectionView: View {
 
 struct LocationRowView: View {
     let location: Location
+    let productViewModel: ProductViewModel
+    @State private var showEditLocation: Bool = false
     
     var body: some View {
-        HStack(spacing: 16) {
+        Button(action: {
+            showEditLocation = true
+        }) {
+            HStack(spacing: 16) {
             // Enhanced Location icon
             ZStack {
                 RoundedRectangle(cornerRadius: 12)
@@ -278,17 +283,23 @@ struct LocationRowView: View {
             
             Spacer()
             
-            // Arrow
-            Image(systemName: "chevron.right")
-                .font(.system(size: 14, weight: .medium))
-                .foregroundColor(.gray.opacity(0.6))
+            // Edit Icon
+            Image(systemName: "pencil.circle.fill")
+                .font(.system(size: 20, weight: .medium))
+                .foregroundColor(AppColors.accentGreen)
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.white)
+                    .shadow(color: Color.black.opacity(0.06), radius: 8, x: 0, y: 4)
+            )
         }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(Color.white)
-                .shadow(color: Color.black.opacity(0.06), radius: 8, x: 0, y: 4)
-        )
+        .buttonStyle(PlainButtonStyle())
+        .sheet(isPresented: $showEditLocation) {
+            EditLocationView(location: location)
+                .environmentObject(productViewModel)
+        }
     }
     
     private func formatAddress() -> String {

--- a/CartWise/Views/LocationsSectionView.swift
+++ b/CartWise/Views/LocationsSectionView.swift
@@ -16,31 +16,75 @@ struct LocationsSectionView: View {
     @State private var isLoading: Bool = true
     
     var body: some View {
-        VStack(spacing: 16) {
-            // Header
+        VStack(alignment: .leading, spacing: 20) {
+            // Enhanced Header
             HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("My Locations")
-                        .font(.poppins(size: 20, weight: .bold))
-                        .foregroundColor(AppColors.textPrimary)
+                ZStack {
+                    Circle()
+                        .fill(
+                            LinearGradient(
+                                gradient: Gradient(colors: [
+                                    AppColors.accentGreen.opacity(0.2),
+                                    AppColors.accentGreen.opacity(0.1)
+                                ]),
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .frame(width: 40, height: 40)
                     
-                    Text("Your favorite shopping locations")
-                        .font(.poppins(size: 14, weight: .regular))
-                        .foregroundColor(.gray)
+                    Image(systemName: "location.circle.fill")
+                        .foregroundColor(AppColors.accentGreen)
+                        .font(.system(size: 18, weight: .medium))
                 }
+                
+                Text("My Locations")
+                    .font(.poppins(size: 22, weight: .bold))
+                    .foregroundColor(.primary)
+                    .shadow(color: Color.black.opacity(0.1), radius: 1, x: 0, y: 1)
                 
                 Spacer()
                 
-                Button(action: {
-                    showAddLocation = true
-                }) {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.system(size: 24))
-                        .foregroundColor(AppColors.accentGreen)
+                HStack(spacing: 8) {
+                    Text("\(locations.count) locations")
+                        .font(.poppins(size: 15, weight: .medium))
+                        .foregroundColor(.gray)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.gray.opacity(0.1))
+                        )
+                    
+                    Button(action: {
+                        showAddLocation = true
+                    }) {
+                        ZStack {
+                            Circle()
+                                .fill(
+                                    LinearGradient(
+                                        gradient: Gradient(colors: [
+                                            AppColors.accentGreen.opacity(0.2),
+                                            AppColors.accentGreen.opacity(0.1)
+                                        ]),
+                                        startPoint: .topLeading,
+                                        endPoint: .bottomTrailing
+                                    )
+                                )
+                                .frame(width: 32, height: 32)
+                            
+                            Image(systemName: "plus")
+                                .foregroundColor(AppColors.accentGreen)
+                                .font(.system(size: 14, weight: .medium))
+                        }
+                    }
+                    .buttonStyle(PlainButtonStyle())
                 }
             }
+            .padding(.horizontal, 20)
+            .padding(.top, 8)
             
-            // Locations List
+            // Enhanced Locations List
             if isLoading {
                 VStack(spacing: 12) {
                     ProgressView()
@@ -50,22 +94,40 @@ struct LocationsSectionView: View {
                         .foregroundColor(.gray)
                 }
                 .frame(height: 100)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 40)
             } else if locations.isEmpty {
-                // Empty State
-                VStack(spacing: 16) {
-                    Image(systemName: "heart.slash")
-                        .font(.system(size: 48))
-                        .foregroundColor(.gray.opacity(0.6))
+                // Enhanced Empty State
+                VStack(spacing: 20) {
+                    ZStack {
+                        Circle()
+                            .fill(
+                                LinearGradient(
+                                    gradient: Gradient(colors: [
+                                        Color.gray.opacity(0.1),
+                                        Color.gray.opacity(0.05)
+                                    ]),
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                )
+                            )
+                            .frame(width: 80, height: 80)
+                        
+                        Image(systemName: "heart.slash")
+                            .font(.system(size: 36, weight: .light))
+                            .foregroundColor(.gray.opacity(0.6))
+                    }
                     
                     VStack(spacing: 8) {
-                        Text("No Favorite Locations")
-                            .font(.poppins(size: 18, weight: .semibold))
-                            .foregroundColor(AppColors.textPrimary)
+                        Text("No favorite locations yet")
+                            .font(.poppins(size: 20, weight: .semibold))
+                            .foregroundColor(.gray)
                         
                         Text("Add locations and mark them as favorites to see them here")
-                            .font(.poppins(size: 14, weight: .regular))
-                            .foregroundColor(.gray)
+                            .font(.poppins(size: 15, weight: .regular))
+                            .foregroundColor(.gray.opacity(0.7))
                             .multilineTextAlignment(.center)
+                            .padding(.horizontal, 20)
                     }
                     
                     Button(action: {
@@ -86,25 +148,27 @@ struct LocationsSectionView: View {
                         )
                     }
                 }
-                .frame(height: 200)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 40)
             } else {
-                // Scrollable Locations List
+                // Enhanced Locations List
                 ScrollView {
-                    LazyVStack(spacing: 12) {
+                    LazyVStack(spacing: 16) {
                         ForEach(locations) { location in
                             LocationRowView(location: location)
                         }
                     }
+                    .padding(.horizontal, 20)
                 }
-                .frame(maxHeight: 300) // Limit height to prevent exponential expansion
+                .frame(maxHeight: 320)
             }
         }
-        .padding(20)
         .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.white)
+            RoundedRectangle(cornerRadius: 24)
+                .fill(Color(.systemBackground))
                 .shadow(color: Color.black.opacity(0.08), radius: 16, x: 0, y: 8)
         )
+        .padding(.vertical, 16)
         .task {
             await loadLocations()
         }
@@ -158,24 +222,36 @@ struct LocationRowView: View {
     let location: Location
     
     var body: some View {
-        HStack(spacing: 12) {
-            // Location Icon
+        HStack(spacing: 16) {
+            // Enhanced Location icon
             ZStack {
-                Circle()
-                    .fill(AppColors.accentGreen.opacity(0.1))
-                    .frame(width: 40, height: 40)
-                
-                Image(systemName: "heart.fill")
-                    .font(.system(size: 18))
-                    .foregroundColor(.red)
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(
+                        LinearGradient(
+                            gradient: Gradient(colors: [
+                                AppColors.accentGreen.opacity(0.2),
+                                AppColors.accentGreen.opacity(0.1)
+                            ]),
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 56, height: 56)
+                    .overlay(
+                        Image(systemName: "location.circle.fill")
+                            .foregroundColor(AppColors.accentGreen)
+                            .font(.system(size: 24, weight: .medium))
+                    )
+                    .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
             }
             
-            // Location Details
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 6) {
                 HStack(spacing: 8) {
                     Text(location.name ?? "Unknown Location")
-                        .font(.poppins(size: 16, weight: .semibold))
-                        .foregroundColor(AppColors.textPrimary)
+                        .font(.poppins(size: 17, weight: .semibold))
+                        .foregroundColor(.primary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
                     
                     if location.isDefault {
                         Image(systemName: "star.fill")
@@ -187,7 +263,17 @@ struct LocationRowView: View {
                 Text(formatAddress())
                     .font(.poppins(size: 14, weight: .regular))
                     .foregroundColor(.gray)
-                    .lineLimit(1)
+                    .lineLimit(2)
+                
+                HStack(spacing: 4) {
+                    Image(systemName: "heart.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(.red)
+                    Text("Favorite Location")
+                        .font(.poppins(size: 12, weight: .medium))
+                        .foregroundColor(.red)
+                        .lineLimit(1)
+                }
             }
             
             Spacer()
@@ -197,11 +283,20 @@ struct LocationRowView: View {
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(.gray.opacity(0.6))
         }
-        .padding(.vertical, 8)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color.white)
+                .shadow(color: Color.black.opacity(0.06), radius: 8, x: 0, y: 4)
+        )
     }
     
     private func formatAddress() -> String {
         var components: [String] = []
+        
+        if let address = location.address, !address.isEmpty {
+            components.append(address)
+        }
         
         if let city = location.city, !city.isEmpty {
             components.append(city)

--- a/CartWise/Views/LocationsSectionView.swift
+++ b/CartWise/Views/LocationsSectionView.swift
@@ -224,10 +224,7 @@ struct LocationRowView: View {
     @State private var showEditLocation: Bool = false
     
     var body: some View {
-        Button(action: {
-            showEditLocation = true
-        }) {
-            HStack(spacing: 16) {
+        HStack(spacing: 16) {
             // Enhanced Location icon
             ZStack {
                 RoundedRectangle(cornerRadius: 12)
@@ -283,19 +280,22 @@ struct LocationRowView: View {
             
             Spacer()
             
-            // Edit Icon
-            Image(systemName: "pencil.circle.fill")
-                .font(.system(size: 20, weight: .medium))
-                .foregroundColor(AppColors.accentGreen)
+            // Edit Icon Button
+            Button(action: {
+                showEditLocation = true
+            }) {
+                Image(systemName: "pencil.circle.fill")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(AppColors.accentGreen)
             }
-            .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(Color.white)
-                    .shadow(color: Color.black.opacity(0.06), radius: 8, x: 0, y: 4)
-            )
+            .buttonStyle(PlainButtonStyle())
         }
-        .buttonStyle(PlainButtonStyle())
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color.white)
+                .shadow(color: Color.black.opacity(0.06), radius: 8, x: 0, y: 4)
+        )
         .sheet(isPresented: $showEditLocation) {
             EditLocationView(location: location)
                 .environmentObject(productViewModel)

--- a/CartWise/Views/LocationsSectionView.swift
+++ b/CartWise/Views/LocationsSectionView.swift
@@ -24,7 +24,7 @@ struct LocationsSectionView: View {
                         .font(.poppins(size: 20, weight: .bold))
                         .foregroundColor(AppColors.textPrimary)
                     
-                    Text("Manage your shopping locations")
+                    Text("Your favorite shopping locations")
                         .font(.poppins(size: 14, weight: .regular))
                         .foregroundColor(.gray)
                 }
@@ -53,16 +53,16 @@ struct LocationsSectionView: View {
             } else if locations.isEmpty {
                 // Empty State
                 VStack(spacing: 16) {
-                    Image(systemName: "location.slash")
+                    Image(systemName: "heart.slash")
                         .font(.system(size: 48))
                         .foregroundColor(.gray.opacity(0.6))
                     
                     VStack(spacing: 8) {
-                        Text("No Locations Yet")
+                        Text("No Favorite Locations")
                             .font(.poppins(size: 18, weight: .semibold))
                             .foregroundColor(AppColors.textPrimary)
                         
-                        Text("Add your favorite shopping locations to track prices")
+                        Text("Add locations and mark them as favorites to see them here")
                             .font(.poppins(size: 14, weight: .regular))
                             .foregroundColor(.gray)
                             .multilineTextAlignment(.center)
@@ -74,7 +74,7 @@ struct LocationsSectionView: View {
                         HStack(spacing: 8) {
                             Image(systemName: "plus.circle.fill")
                                 .font(.system(size: 16, weight: .medium))
-                            Text("Add First Location")
+                            Text("Add Location")
                                 .font(.poppins(size: 16, weight: .semibold))
                         }
                         .foregroundColor(AppColors.accentGreen)
@@ -88,26 +88,15 @@ struct LocationsSectionView: View {
                 }
                 .frame(height: 200)
             } else {
-                // Locations List
-                VStack(spacing: 12) {
-                    ForEach(locations.prefix(3)) { location in
-                        LocationRowView(location: location)
-                    }
-                    
-                    if locations.count > 3 {
-                        Button(action: {
-                            // TODO: Navigate to full locations list
-                        }) {
-                            HStack(spacing: 8) {
-                                Text("View All \(locations.count) Locations")
-                                    .font(.poppins(size: 14, weight: .medium))
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 12, weight: .medium))
-                            }
-                            .foregroundColor(AppColors.accentGreen)
+                // Scrollable Locations List
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(locations) { location in
+                            LocationRowView(location: location)
                         }
                     }
                 }
+                .frame(maxHeight: 300) // Limit height to prevent exponential expansion
             }
         }
         .padding(20)
@@ -142,12 +131,11 @@ struct LocationsSectionView: View {
             let users = try viewContext.fetch(fetchRequest)
             guard let currentUser = users.first else { return }
             
-            // Fetch user's locations
+            // Fetch only favorited locations
             let locationFetchRequest: NSFetchRequest<Location> = Location.fetchRequest()
-            locationFetchRequest.predicate = NSPredicate(format: "user == %@", currentUser)
+            locationFetchRequest.predicate = NSPredicate(format: "user == %@ AND favorited == YES", currentUser)
             locationFetchRequest.sortDescriptors = [
                 NSSortDescriptor(keyPath: \Location.isDefault, ascending: false),
-                NSSortDescriptor(keyPath: \Location.favorited, ascending: false),
                 NSSortDescriptor(keyPath: \Location.name, ascending: true)
             ]
             
@@ -177,9 +165,9 @@ struct LocationRowView: View {
                     .fill(AppColors.accentGreen.opacity(0.1))
                     .frame(width: 40, height: 40)
                 
-                Image(systemName: "location.circle.fill")
-                    .font(.system(size: 20))
-                    .foregroundColor(AppColors.accentGreen)
+                Image(systemName: "heart.fill")
+                    .font(.system(size: 18))
+                    .foregroundColor(.red)
             }
             
             // Location Details
@@ -193,12 +181,6 @@ struct LocationRowView: View {
                         Image(systemName: "star.fill")
                             .font(.system(size: 12))
                             .foregroundColor(.yellow)
-                    }
-                    
-                    if location.favorited {
-                        Image(systemName: "heart.fill")
-                            .font(.system(size: 12))
-                            .foregroundColor(.red)
                     }
                 }
                 


### PR DESCRIPTION
- only favorite store should display, but people can add more locations that just dont display
- >> Tested that only favorite stores appear. I tested that the user can add more locations that are not favorites. Those not favorites do not get displayed in list.

- make sure it can scroll and doesnt expand exponentially (test by adding lots of stores)
- >> Scroll is enabled to make sure that the list does not expand exponentially. About 3 stores are displayed initially

- when adding location, make sure address hasn't already been added (maybe some kinda search when typing)
- >> Warning is given to user if the address is the same. User is unable to add location afterward.

- fix UI to be more in line with your list
- >> Should be similar in style to the rest of the profile page


Please let me know if you have any questions or concerns