### PR TITLE
Fix category filtering and price instruction text

### DIFF
--- a/CartWise/Views/CategoryItemsView.swift
+++ b/CartWise/Views/CategoryItemsView.swift
@@ -26,21 +26,19 @@ struct CategoryItemsView: View {
         // Load all products and filter by category
         let allProducts = await viewModel.fetchAllProducts()
         let filtered = allProducts.filter { groceryItem in
-            // First check if the category field matches
-            if let productCategory = groceryItem.category {
-                if productCategory.lowercased() == category.rawValue.lowercased() {
-                    return true
-                }
+            // Primary: Check if category field matches (set from barcode scanning)
+            if let productCategory = groceryItem.category, !productCategory.isEmpty {
+                return productCategory.lowercased() == category.rawValue.lowercased()
             }
-            // Then check product name against category keywords
+            
+            // Fallback: Use keyword matching only for products without category (legacy data)
             if let productName = groceryItem.productName {
                 let categoryKeywords = getCategoryKeywords(for: category)
-                let matches = categoryKeywords.contains { keyword in
+                return categoryKeywords.contains { keyword in
                     productName.lowercased().contains(keyword.lowercased())
                 }
-                print("CategoryItemsView: Filtering by name: \(productName) - Keywords: \(categoryKeywords) - Matches: \(matches)")
-                return matches
             }
+            
             return false
         }
         print("CategoryItemsView: Total products: \(allProducts.count), Filtered products: \(filtered.count)")
@@ -58,9 +56,9 @@ struct CategoryItemsView: View {
         case .dairy:
             return ["dairy", "eggs", "milk", "cheese", "yogurt", "butter", "cream"]
         case .bakery:
-            return ["bakery", "bread", "pastry", "cake", "cookie", "muffin", "donut"]
+            return ["bakery", "bread", "pastry", "cake", "cookie", "muffin", "donut", "croissant", "bagel", "pretzel", "scone", "waffle", "pancake"]
         case .produce:
-            return ["produce", "vegetable", "fruit", "fresh", "organic", "apple", "banana", "tomato"]
+            return ["produce", "vegetable", "fruit", "apple", "banana", "tomato", "lettuce", "carrot", "onion", "potato", "broccoli", "spinach", "cucumber", "bell pepper", "orange", "grape", "strawberry", "avocado"]
         case .pantry:
             return ["pantry", "canned", "staple", "rice", "pasta", "sauce", "condiment"]
         case .beverages:
@@ -735,7 +733,7 @@ struct ProductPriceView: View {
                     Text("at \(currentSelectedLocation?.name ?? "Unknown Location")")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundColor(.secondary)
-                    Text("Tap 'Update Price' to add a price for this location")
+                    Text("Tap 'Edit' to add a price for this location")
                         .font(.system(size: 12))
                         .foregroundColor(.gray.opacity(0.7))
                         .multilineTextAlignment(.center)


### PR DESCRIPTION
- Prioritize stored category field over keyword matching (keyword matching was used for API searches previously)
- Use keyword matching only as fallback for legacy products without categories (in case category was not selected, or if we decide to go back to API searches)
- Change "Update Price" to "Edit" instruction to match actual button (no more 'Update Price' button)

<p align=center>
<img width="240" height="680" alt="image" src="https://github.com/user-attachments/assets/f36bf3d6-79c8-4b81-a963-1af883ce5969" hspace="10" />

<img width="240" height="680" alt="image" src="https://github.com/user-attachments/assets/38108257-fe3f-4f87-9d52-60f3831f8747" hspace="10" />
<p/>


